### PR TITLE
fix: flow error of ShareSheet

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ const requireAndAskPermissions = async (options: Options | MultipleOptions): Pro
 
 class RNShare {
   static Button: any;
-  static ShareSheet: React.Element<*>;
+  static ShareSheet: Class<React.Component<Props>>;
   static Overlay: any;
   static Sheet: any;
   static Social = {


### PR DESCRIPTION
#2 not work well on our environment.

```
$ yarn flow check
yarn run v1.13.0
$ /Users/set0gut1/github/standfm/projects/app/node_modules/.bin/flow check
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/react-native-share/index.js:257:29

Cannot assign ShareSheet to module.exports.ShareSheet because inexact class ShareSheet [1] is incompatible with exact
React.Element [2].

 [1]  41│ class ShareSheet extends React.Component<Props> {
        :
 [2] 148│   static ShareSheet: React.Element<*>;
        :
     254│ module.exports.Overlay = Overlay;
     255│ module.exports.Sheet = Sheet;
     256│ module.exports.Button = Button;
     257│ module.exports.ShareSheet = ShareSheet;
     258│



Found 1 error
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

The flow error disappeared with this PR's change.