### PR TITLE
backgroundImageを受け取っていなかった

### DIFF
--- a/android/src/main/java/cl/json/social/InstagramStoriesShare.java
+++ b/android/src/main/java/cl/json/social/InstagramStoriesShare.java
@@ -43,9 +43,9 @@ public class InstagramStoriesShare extends SingleShareIntent {
             Uri backgroundVideoUri = backgroundVideoFile.getURI();
             this.getIntent().setDataAndType(backgroundVideoUri, "video/mp4");
         } else if (options.hasKey("backgroundImage")) {
-            ShareFile backgroundVideoFile = new ShareFile(options.getString("backgroundImage"), "image/jpg", this.reactContext);
-            Uri backgroundVideoUri = backgroundVideoFile.getURI();
-            this.getIntent().setDataAndType(backgroundVideoUri, "image/jpg");
+            ShareFile backgroundImageFile = new ShareFile(options.getString("backgroundImage"), "image/jpg", this.reactContext);
+            Uri backgroundImageUri = backgroundImageFile.getURI();
+            this.getIntent().setDataAndType(backgroundImageUri, "image/jpg");
         }
 
         if (options.hasKey("stickerImage")) {


### PR DESCRIPTION
関連: https://github.com/newn-team/standfm/pull/2107

https://developers.facebook.com/docs/instagram/sharing-to-stories/#sharing-a-background-asset-and-a-sticker-asset
stickerとbackground両方渡すときはstickerのtypeはセットしなくていいらしい
(セットすると正しくbackgroundが表示されなかった)