### PR TITLE
コンスタラクタ名修正

### DIFF
--- a/android/src/main/java/cl/json/social/InstagramStoriesVideoAndStickerImageShare.java
+++ b/android/src/main/java/cl/json/social/InstagramStoriesVideoAndStickerImageShare.java
@@ -18,7 +18,7 @@ public class InstagramStoriesVideoAndStickerImageShare extends SingleShareIntent
     private static final String PACKAGE = "com.instagram.android";
     private static final String PLAY_STORE_LINK = "market://details?id=com.instagram.android";
 
-    public InstagramStoriesShare(ReactApplicationContext reactContext) {
+    public InstagramStoriesVideoAndStickerImageShare(ReactApplicationContext reactContext) {
         super(reactContext);
         this.setIntent(new Intent("com.instagram.share.ADD_TO_STORY"));
     }


### PR DESCRIPTION

コンストラクタ名がクラス名と一致せず以下のエラーが出ていたようでした。
```
react-native-share/android/src/main/java/cl/json/social/InstagramStoriesVideoAndStickerImageShare.java:21: 
エラー: 無効なメソッド宣言です。戻り値の型が必要です。
    public InstagramStoriesShare(ReactApplicationContext reactContext) {
           ^
エラー1個
```

コンストラクタ名を変更しました。

appのpackage.jsonも変更しないと行けないかもです。
https://github.com/newn-team/standfm/blob/master/projects/app/package.json#L93
マージ後に対応したいと思います。